### PR TITLE
Minor UI Cleanup / Fixes

### DIFF
--- a/platform.io/src/buzzer.c
+++ b/platform.io/src/buzzer.c
@@ -61,7 +61,7 @@ static void onPulseClicksMenuSelect(const Menu *menu)
 static MenuState pulseClicksMenuState;
 
 static const Menu pulseClicksMenu = {
-    "Pulse clicks",
+    "Pulse Clicks",
     &pulseClicksMenuState,
     onPulseClicksMenuGetOption,
     onPulseClicksMenuSelect,

--- a/platform.io/src/comm.c
+++ b/platform.io/src/comm.c
@@ -293,7 +293,7 @@ static void onDataModeMenuSelect(const Menu *menu)
 static MenuState dataModeMenuState;
 
 static const Menu dataModeMenu = {
-    "Data mode",
+    "Data Mode",
     &dataModeMenuState,
     onDataModeMenuGetOption,
     onDataModeMenuSelect,

--- a/platform.io/src/datalog.c
+++ b/platform.io/src/datalog.c
@@ -53,13 +53,13 @@ static const uint16_t datalogTimeIntervals[] = {
 
 static const char *const datalogMenuOptions[] = {
     "Off",
-    "Every 60 minutes",
-    "Every 30 minutes",
-    "Every 10 minutes",
-    "Every 5 minutes",
-    "Every minute",
-    "Every 30 seconds",
-    "Every 10 seconds",
+    "Every 60 Minutes",
+    "Every 30 Minutes",
+    "Every 10 Minutes",
+    "Every 5 Minutes",
+    "Every Minute",
+    "Every 30 Seconds",
+    "Every 10 Seconds",
     NULL,
 };
 
@@ -383,7 +383,7 @@ static void onDatalogMenuSelect(const Menu *menu)
 static MenuState datalogMenuState;
 
 static const Menu datalogMenu = {
-    "Data logging",
+    "Data Logging",
     &datalogMenuState,
     onDatalogMenuGetOption,
     onDatalogMenuSelect,

--- a/platform.io/src/display.c
+++ b/platform.io/src/display.c
@@ -1915,9 +1915,9 @@ void drawStatistics(void)
 
         case STATISTICS_ENTRY_TUBE_LIFE_TIME:
 #if !defined(DISPLAY_PORTRAIT)
-            strcpy(key, "Tube life time");
+            strcpy(key, "Tube Life Time:");
 #else
-            strcpy(key, "Life time");
+            strcpy(key, "Life Time:");
 #endif
             strcatTime(valueString, getTubeTime());
 
@@ -1925,9 +1925,9 @@ void drawStatistics(void)
 
         case STATISTICS_ENTRY_TUBE_LIFE_PULSES:
 #if !defined(DISPLAY_PORTRAIT)
-            strcpy(key, "Tube life pulses");
+            strcpy(key, "Tube Life Pulses:");
 #else
-            strcpy(key, "Life pulses");
+            strcpy(key, "Life Pulses:");
 #endif
             strcatUInt32(valueString, getTubePulseCount(), 0);
 
@@ -1935,9 +1935,9 @@ void drawStatistics(void)
 
         case STATISTICS_ENTRY_TUBE_DEAD_TIME:
 #if !defined(DISPLAY_PORTRAIT)
-            strcpy(key, "Tube dead time");
+            strcpy(key, "Tube Dead Time:");
 #else
-            strcpy(key, "Life pulses");
+            strcpy(key, "Dead Time:");
 #endif
             float deadTime = getTubeDeadTime();
             if (deadTime >= 1)
@@ -1961,9 +1961,9 @@ void drawStatistics(void)
 
         case STATISTICS_ENTRY_DEVICE_ID:
 #if !defined(DISPLAY_PORTRAIT)
-            strcpy(key, "Device ID");
+            strcpy(key, "Device ID:");
 #else
-            strcpy(key, "ID");
+            strcpy(key, "ID:");
 #endif
             strcatUInt32Hex(unitString, getDeviceId());
 
@@ -1971,9 +1971,9 @@ void drawStatistics(void)
 
         case STATISTICS_ENTRY_DEVICE_VOLTAGE:
 #if !defined(DISPLAY_PORTRAIT)
-            strcpy(key, "Device voltage");
+            strcpy(key, "Device Voltage:");
 #else
-            strcpy(key, "Voltage");
+            strcpy(key, "Voltage:");
 #endif
             strcatFloat(valueString, getDeviceBatteryVoltage(), 3);
             strcpy(unitString, " V");
@@ -2197,6 +2197,29 @@ void drawGame(const uint8_t board[8][8],
 #endif
 }
 
+// Comm mode
+
+void drawDataMode(void)
+{
+    drawTitleBar("Data Mode");
+
+    const mr_rectangle_t dataModeRectangle = {
+        DATA_MODE_X,
+        DATA_MODE_Y,
+        DATA_MODE_WIDTH,
+        DATA_MODE_HEIGHT};
+
+    const mr_point_t dataModeOffset = {
+        DATA_MODE_OFFSET_X,
+        DATA_MODE_OFFSET_Y};
+
+    setFont(FONT_SMALL);
+    setTextColor(COLOR_ELEMENT_NEUTRAL);
+    drawCenteredText("Data connection enabled.",
+                     &dataModeRectangle,
+                     &dataModeOffset);
+}
+
 // Display menu
 
 const View displayContrastMenuView;
@@ -2210,9 +2233,9 @@ static const OptionView displayMenuOptions[] = {
 #elif defined(DISPLAY_COLOR)
     {"Theme", &displayThemeMenuView},
 #endif
-    {"Brightness level", &displayBrightnessMenuView},
+    {"Brightness Level", &displayBrightnessMenuView},
 #if defined(DISPLAY_MONOCHROME)
-    {"Backlight", &displaySleepMenuView},
+    {"Backlight Timeout", &displaySleepMenuView},
 #elif defined(DISPLAY_COLOR)
     {"Sleep", &displaySleepMenuView},
 #endif
@@ -2343,7 +2366,7 @@ const View displayThemeMenuView = {
 // Display brightness level menu
 
 static const char *const displayBrightnessMenuOptions[] = {
-    "Very low",
+    "Very Low",
     "Low",
     "Medium",
     "High",
@@ -2369,7 +2392,7 @@ static void onDisplayBrightnessMenuSelect(const Menu *menu)
 static MenuState displayBrightnessMenuState;
 
 static const Menu displayBrightnessMenu = {
-    "Brightness level",
+    "Brightness Level",
     &displayBrightnessMenuState,
     onDisplayBrightnessMenuGetOption,
     onDisplayBrightnessMenuSelect,
@@ -2385,19 +2408,19 @@ const View displayBrightnessMenuView = {
 
 static const char *const displaySleepMenuOptions[] = {
 #if defined(DISPLAY_MONOCHROME)
-    "Off",
+    "Always Off",
 #endif
 #if !defined(DISPLAY_240X320)
-    "On for 10 seconds",
-    "On for 30 seconds",
+    "After 10 Seconds",
+    "After 30 Seconds",
 #else
-    "On for 10 sec.",
-    "On for 30 sec.",
+    "After 10 Sec.",
+    "After 30 Sec.",
 #endif
-    "On for 1 minute",
-    "On for 2 minutes",
-    "On for 5 minutes",
-    "Always on",
+    "After 1 Minute",
+    "After 2 Minutes",
+    "After 5 Minutes",
+    "Never",
     NULL,
 };
 
@@ -2421,7 +2444,7 @@ static MenuState displaySleepMenuState;
 
 static const Menu displaySleepMenu = {
 #if defined(DISPLAY_MONOCHROME)
-    "Backlight",
+    "Backlight Timeout",
 #elif defined(DISPLAY_COLOR)
     "Sleep",
 #endif
@@ -2461,7 +2484,7 @@ static void onDisplayFlashesMenuSelect(const Menu *menu)
 static MenuState displayFlashesMenuState;
 
 static const Menu displayFlashesMenu = {
-    "Display flashes",
+    "Display Flashes",
     &displayFlashesMenuState,
     onDisplayFlashesMenuGetOption,
     onDisplayFlashesMenuSelect,

--- a/platform.io/src/display.c
+++ b/platform.io/src/display.c
@@ -2197,29 +2197,6 @@ void drawGame(const uint8_t board[8][8],
 #endif
 }
 
-// Comm mode
-
-void drawDataMode(void)
-{
-    drawTitleBar("Data Mode");
-
-    const mr_rectangle_t dataModeRectangle = {
-        DATA_MODE_X,
-        DATA_MODE_Y,
-        DATA_MODE_WIDTH,
-        DATA_MODE_HEIGHT};
-
-    const mr_point_t dataModeOffset = {
-        DATA_MODE_OFFSET_X,
-        DATA_MODE_OFFSET_Y};
-
-    setFont(FONT_SMALL);
-    setTextColor(COLOR_ELEMENT_NEUTRAL);
-    drawCenteredText("Data connection enabled.",
-                     &dataModeRectangle,
-                     &dataModeOffset);
-}
-
 // Display menu
 
 const View displayContrastMenuView;

--- a/platform.io/src/display.c
+++ b/platform.io/src/display.c
@@ -115,7 +115,7 @@
 #define CONTENT_PADDING 3
 
 #define TITLEBAR_HEIGHT 8
-#define TITLEBAR_CLOCK_WIDTH 20
+#define TITLEBAR_CLOCK_WIDTH 30
 #define TITLEBAR_BATTERY_WIDTH 15
 #define TITLEBAR_BATTERY_OFFSET_Y 1
 
@@ -163,7 +163,7 @@
 #define CONTENT_PADDING 12
 
 #define TITLEBAR_HEIGHT 40
-#define TITLEBAR_CLOCK_WIDTH 53
+#define TITLEBAR_CLOCK_WIDTH 73
 #define TITLEBAR_BATTERY_WIDTH 41
 #define TITLEBAR_BATTERY_OFFSET_Y ((TITLEBAR_HEIGHT - 30) / 2)
 
@@ -211,7 +211,7 @@
 #define CONTENT_PADDING 12
 
 #define TITLEBAR_HEIGHT 40
-#define TITLEBAR_CLOCK_WIDTH 53
+#define TITLEBAR_CLOCK_WIDTH 73
 #define TITLEBAR_BATTERY_WIDTH 41
 #define TITLEBAR_BATTERY_OFFSET_Y ((TITLEBAR_HEIGHT - 30) / 2)
 
@@ -913,7 +913,7 @@ void drawTitleBar(const char *title)
 
     mr_rectangle_t rectangle;
     mr_point_t offset;
-    char buffer[6];
+    char buffer[8];
 
     rectangle.y = TITLEBAR_Y;
     rectangle.height = TITLEBAR_HEIGHT;
@@ -932,22 +932,44 @@ void drawTitleBar(const char *title)
 
     // Time
     RTCDateTime dateTime;
+    
+    
     getDeviceDateTime(&dateTime);
+
+    bool show12H = (settings.displayTimeFormat == DISPLAY_TIMEFORMAT_12H);
+    int8_t hour = dateTime.hour;
+
+    if(show12H) {
+        if(hour == 0) {
+            hour = 12;
+        } else if (hour > 12) {
+            hour -= 12;
+        }
+    }
 
     strclr(buffer);
     if (dateTime.year >= RTC_YEAR_MIN)
     {
-        strcatUInt32(buffer, dateTime.hour, 2);
+        strcatUInt32(buffer, hour, (show12H && (hour < 10)) ? 1 : 2);
         strcatChar(buffer, ':');
         strcatUInt32(buffer, dateTime.minute, 2);
+
+        if(show12H) {
+            if(dateTime.hour >= 12) {
+                strcatChar(buffer, 'P');
+            } else {
+                strcatChar(buffer, 'A');
+            }
+            strcatChar(buffer, 'M');
+        }
     }
 
     rectangle.x = TITLEBAR_CLOCK_X;
     rectangle.width = TITLEBAR_CLOCK_WIDTH;
-    offset.x = 0;
+    offset.x = TITLEBAR_CLOCK_WIDTH;
 
     setTextColor(COLOR_ELEMENT_NEUTRAL);
-    drawText(buffer,
+    drawRightAlignedText(buffer,
              &rectangle,
              &offset);
 

--- a/platform.io/src/game.c
+++ b/platform.io/src/game.c
@@ -428,15 +428,15 @@ const View gameView = {
 static const View gameStrengthMenuView;
 
 static const char *const gameStartMenuOptions[] = {
-    "Play white",
-    "Play black",
+    "Play White",
+    "Play Black",
     "Strength",
     NULL,
 };
 
 static const char *const gameContinueMenuOptions[] = {
-    "Continue game",
-    "New game",
+    "Continue Game",
+    "New Game",
     "Strength",
     NULL,
 };

--- a/platform.io/src/measurements.c
+++ b/platform.io/src/measurements.c
@@ -96,9 +96,9 @@ typedef struct
 } History;
 
 static const History histories[] = {
-    {"History (10 min)", 10 * 60 / HISTORY_BUFFER_SIZE, 10},
-    {"History (1 h)", 60 * 60 / HISTORY_BUFFER_SIZE, 6},
-    {"History (24 h)", 24 * 60 * 60 / HISTORY_BUFFER_SIZE, 8},
+    {"History (10M)", 10 * 60 / HISTORY_BUFFER_SIZE, 10},
+    {"History (1H)", 60 * 60 / HISTORY_BUFFER_SIZE, 6},
+    {"History (24H)", 24 * 60 * 60 / HISTORY_BUFFER_SIZE, 8},
 };
 
 #define HISTORY_NUM (sizeof(histories) / sizeof(History))
@@ -1322,18 +1322,18 @@ const View unitsMenuView = {
 
 static const char *const averagingMenuOptions[] = {
     "Unlimited",
-    "5 minutes",
-    "10 minutes",
-    "30 minutes",
-    "60 minutes",
+    "5 Minutes",
+    "10 Minutes",
+    "30 Minutes",
+    "60 Minutes",
     "\xb1"
-    "40% confidence",
+    "40% Confidence",
     "\xb1"
-    "20% confidence",
+    "20% Confidence",
     "\xb1"
-    "10% confidence",
+    "10% Confidence",
     "\xb1"
-    "5% confidence",
+    "5% Confidence",
     NULL,
 };
 
@@ -1405,7 +1405,7 @@ static void onRateAlarmMenuSelect(const Menu *menu)
 static MenuState rateAlarmMenuState;
 
 static const Menu rateAlarmMenu = {
-    "Rate alarm",
+    "Rate Alarm",
     &rateAlarmMenuState,
     onRateAlarmMenuGetOption,
     onRateAlarmMenuSelect,
@@ -1453,7 +1453,7 @@ static void onDoseAlarmMenuSelect(const Menu *menu)
 static MenuState doseAlarmMenuState;
 
 static const Menu doseAlarmMenu = {
-    "Dose alarm",
+    "Dose Alarm",
     &doseAlarmMenuState,
     onDoseAlarmMenuGetOption,
     onDoseAlarmMenuSelect,
@@ -1489,7 +1489,7 @@ static void onPulsesThresholdMenuSelect(const Menu *menu)
 static MenuState pulsesThresholdMenuState;
 
 static const Menu pulsesThresholdMenu = {
-    "Pulses threshold",
+    "Pulses Threshold",
     &pulsesThresholdMenuState,
     onPulsesThresholdMenuGetOption,
     onPulsesThresholdMenuSelect,

--- a/platform.io/src/power.c
+++ b/platform.io/src/power.c
@@ -117,7 +117,7 @@ static void onBatteryTypeMenuSelect(const Menu *menu)
 static MenuState batteryTypeMenuState;
 
 static const Menu batteryTypeMenu = {
-    "Battery type",
+    "Battery Type",
     &batteryTypeMenuState,
     onPulseClicksMenuGetOption,
     onBatteryTypeMenuSelect,

--- a/platform.io/src/rng.c
+++ b/platform.io/src/rng.c
@@ -41,12 +41,12 @@ static const char *const rngModeMenuOptions[] = {
     "Full ASCII",
     "Hexadecimal",
     "Decimal",
-    "20-sided dice",
-    "12-sided dice",
-    "8-sided dice",
-    "6-sided dice",
-    "4-sided dice",
-    "Coin flip",
+    "20-Sided Dice",
+    "12-Sided Dice",
+    "8-Sided Dice",
+    "6-Sided Dice",
+    "4-Sided Dice",
+    "Coin Flip",
     NULL,
 };
 
@@ -296,9 +296,9 @@ static MenuState rngMenuState;
 
 static const Menu rngMenu = {
 #if !defined(DISPLAY_240X320)
-    "Random generator",
+    "Random Generator",
 #else
-    "Random gen.",
+    "Random Gen.",
 #endif
     &rngMenuState,
     onRNGMenuGetOption,

--- a/platform.io/src/rtc.c
+++ b/platform.io/src/rtc.c
@@ -248,7 +248,7 @@ static void onRTCTimeZoneMenuSelect(const Menu *menu)
 }
 
 static const Menu rtcTimeZoneMenu = {
-    "Time zone",
+    "Time Zone",
     &rtcItemMenuState,
     onRTCTimeZoneMenuGetOption,
     onRTCTimeZoneMenuSelect,
@@ -338,7 +338,7 @@ static const View rtcMinuteMenuView = {
 // Date and type menu
 
 static const char *const rtcMenuOptions[] = {
-    "Time zone",
+    "Time Zone",
     "Year",
     "Month",
     "Day",
@@ -417,7 +417,7 @@ static void onRTCMenuSelect(const Menu *menu)
 }
 
 static const Menu rtcMenu = {
-    "Date and time",
+    "Date and Time",
     &rtcMenuState,
     onRTCMenuGetOption,
     onRTCMenuSelect,

--- a/platform.io/src/rtc.c
+++ b/platform.io/src/rtc.c
@@ -14,6 +14,12 @@
 
 static const Menu rtcTimeZoneMenu;
 
+static const char *const displayTimeFormatMenuOptions[] = {
+    "12-Hour",
+    "24-Hour",
+    NULL,
+};
+
 void initRTC(void)
 {
     initRTCController();
@@ -215,11 +221,43 @@ static void onRTCSubMenuBack(const Menu *menu)
 
 static MenuState rtcItemMenuState;
 
+// Display Time Format Menu
+
+static void onDisplayTimeFormatSelect(const Menu *menu)
+{
+    settings.displayTimeFormat = menu->state->selectedIndex;
+
+    //updateView();
+}
+
+static const char *onDisplayTimeFormatMenuGetOption(const Menu *menu,
+                                            uint32_t index,
+                                            MenuStyle *menuStyle)
+{
+    *menuStyle = (index == settings.displayTimeFormat);
+
+    return displayTimeFormatMenuOptions[index];
+}
+
+static const Menu displayTimeFormatMenu = {
+    "Time Format",
+    &rtcItemMenuState,
+    onDisplayTimeFormatMenuGetOption,
+    onDisplayTimeFormatSelect,
+    onRTCSubMenuBack,
+};
+
+static const View displayTimeFormatView = {
+    onMenuEvent,
+    &displayTimeFormatMenu,
+};
+
+
 // Time zone menu
 
 static const char *onRTCTimeZoneMenuGetOption(const Menu *menu,
-                                              uint32_t index,
-                                              MenuStyle *menuStyle)
+                                            uint32_t index,
+                                            MenuStyle *menuStyle)
 {
     if (index >= RTC_TIMEZONE_NUM)
         return NULL;
@@ -344,6 +382,7 @@ static const char *const rtcMenuOptions[] = {
     "Day",
     "Hour",
     "Minute",
+    "Display Format",
     NULL,
 };
 
@@ -406,6 +445,13 @@ static void onRTCMenuSelect(const Menu *menu)
         view = &rtcMinuteMenuView;
         menuIndex = rtcCurrentDateTime.minute;
         optionsNum = 60;
+
+        break;
+
+    case 6:
+        view = &displayTimeFormatView;
+        menuIndex = settings.displayTimeFormat;
+        optionsNum = DISPLAY_TIMEFORMAT_NUM;
 
         break;
     }

--- a/platform.io/src/settings.c
+++ b/platform.io/src/settings.c
@@ -162,25 +162,25 @@ void writeSettings(void)
 static const OptionView settingsMenuOptions[] = {
     {"Units", &unitsMenuView},
     {"Averaging", &averagingMenuView},
-    {"Rate alarm", &rateAlarmMenuView},
-    {"Dose alarm", &doseAlarmMenuView},
-    {"Geiger tube", &tubeMenuView},
-    {"Data logging", &datalogMenuView},
+    {"Rate Alarm", &rateAlarmMenuView},
+    {"Dose Alarm", &doseAlarmMenuView},
+    {"Geiger Tube", &tubeMenuView},
+    {"Data Logging", &datalogMenuView},
     {"Pulses", &pulsesMenuView},
     {"Display", &displayMenuView},
-    {"Date and time", &dateAndTimeMenuView},
+    {"Date and Time", &dateAndTimeMenuView},
 #if defined(BATTERY_REMOVABLE)
-    {"Battery type", &batteryTypeMenuView},
+    {"Battery Type", &batteryTypeMenuView},
 #endif
 #if !defined(DISPLAY_240X320)
-    {"Random generator", &rngMenuView},
+    {"Random Generator", &rngMenuView},
 #else
-    {"Random gen.", &rngMenuView},
+    {"Random Gen.", &rngMenuView},
 #endif
     {"Game", &gameMenuView},
     {"Statistics", &statisticsView},
 #if defined(DATA_MODE)
-    {"Data mode", &dataModeMenuView},
+    {"Data Mode", &dataModeMenuView},
 #endif
     {NULL},
 };

--- a/platform.io/src/settings.c
+++ b/platform.io/src/settings.c
@@ -59,6 +59,7 @@ void initSettings(void)
     settings.displayBrightness = DISPLAY_BRIGHTNESS_HIGH;
 #endif
     settings.displaySleep = DISPLAY_SLEEP_30S;
+    settings.displayTimeFormat = DISPLAY_TIMEFORMAT_24H;
 #if defined(SIMULATOR)
     time_t unixTime = time(NULL);
     struct tm *localTM = gmtime(&unixTime);

--- a/platform.io/src/settings.h
+++ b/platform.io/src/settings.h
@@ -274,6 +274,14 @@ enum
 
 enum
 {
+    DISPLAY_TIMEFORMAT_12H,
+    DISPLAY_TIMEFORMAT_24H,
+
+    DISPLAY_TIMEFORMAT_NUM,
+};
+
+enum
+{
     RTC_TIMEZONE_M1200,
     RTC_TIMEZONE_M1100,
     RTC_TIMEZONE_M1000,
@@ -365,6 +373,7 @@ typedef struct
 #endif
     unsigned int displayBrightness : 2;
     unsigned int displaySleep : 3;
+    unsigned int displayTimeFormat : 1;
 
     unsigned int rtcTimeZone : 5;
 

--- a/platform.io/src/tube.c
+++ b/platform.io/src/tube.c
@@ -66,20 +66,24 @@ void initTube(void)
 // Tube menu
 
 static const char *const tubeMenuOptions[] = {
-    "Conversion factor",
 #if !defined(DISPLAY_240X320)
-    "Instant. averaging",
+    "Conversion Factor",
 #else
-    "Inst. averaging",
+    "Conv. Factor",
 #endif
 #if !defined(DISPLAY_240X320)
-    "Dead-time comp.",
-    "Background comp.",
+    "Instant. Averaging",
 #else
-    "Dead-time com.",
-    "Background com.",
+    "Inst. Averaging",
 #endif
-    "HV profile",
+#if !defined(DISPLAY_240X320)
+    "Dead-Time Comp.",
+    "BG Compensation",
+#else
+    "Dead-Time Com.",
+    "BG Compensation",
+#endif
+    "HV Profile",
     NULL,
 };
 
@@ -113,7 +117,7 @@ void onTubeSubMenuBack(const Menu *menu)
 static MenuState tubeMenuState;
 
 static const Menu tubeMenu = {
-    "Geiger tube",
+    "Geiger Tube",
     &tubeMenuState,
     onTubeMenuGetOption,
     onTubeMenuSelect,
@@ -172,7 +176,7 @@ static const char *onTubeConversionFactorMenuGetOption(const Menu *menu,
         strcpy(menuOption, tubeConversionFactorMenuOptions[index]);
 
         if (index == TUBE_CONVERSIONFACTOR_DEFAULT)
-            strcat(menuOption, " (default)");
+            strcat(menuOption, " (Default)");
 
         return menuOption;
     }
@@ -198,7 +202,11 @@ static void onTubeConversionFactorMenuSelect(const Menu *menu)
 static MenuState tubeConversionFactorMenuState;
 
 static const Menu tubeConversionFactorMenu = {
-    "Conversion factor",
+#if !defined(DISPLAY_240X320)
+    "Conversion Factor",
+#else
+    "Conv. Factor",
+#endif
     &tubeConversionFactorMenuState,
     onTubeConversionFactorMenuGetOption,
     onTubeConversionFactorMenuSelect,
@@ -213,11 +221,11 @@ static const View tubeConversionFactorMenuView = {
 // Instantaneous averaging men
 
 static const char *const tubeInstantaneousAveragingMenuOptions[] = {
-    "Adaptive fast",
-    "Adaptive precision",
-    "60 seconds",
-    "30 seconds",
-    "10 seconds",
+    "Adaptive Fast",
+    "Adaptive Precision",
+    "60 Seconds",
+    "30 Seconds",
+    "10 Seconds",
     NULL,
 };
 
@@ -239,9 +247,9 @@ static MenuState tubeInstantaneousAveragingMenuState;
 
 static const Menu tubeInstantaneousAveragingMenu = {
 #if !defined(DISPLAY_240X320)
-    "Instantaneous averaging",
+    "Instantaneous Averaging",
 #else
-    "Inst. averaging",
+    "Inst. Averaging",
 #endif
     &tubeInstantaneousAveragingMenuState,
     onTubeInstantaneousAveragingMenuGetOption,
@@ -302,9 +310,9 @@ static MenuState tubeDeadTimeCompensationMenuState;
 
 static const Menu tubeDeadTimeCompensationMenu = {
 #if !defined(DISPLAY_240X320)
-    "Dead-time compensation",
+    "Dead-Time Compensation",
 #else
-    "Dead-time com.",
+    "Dead-Time Com.",
 #endif
     &tubeDeadTimeCompensationMenuState,
     onTubeDeadTimeCompensationMenuGetOption,
@@ -367,11 +375,7 @@ static void onTubeBackgroundCompensationMenuSelect(const Menu *menu)
 static MenuState tubeBackgroundCompensationMenuState;
 
 static const Menu tubeBackgroundCompensationMenu = {
-#if !defined(DISPLAY_240X320)
-    "Background compensation",
-#else
-    "Background com.",
-#endif
+    "BG Comp.",
     &tubeBackgroundCompensationMenuState,
     onTubeBackgroundCompensationMenuGetOption,
     onTubeBackgroundCompensationMenuSelect,
@@ -386,14 +390,14 @@ static const View tubeBackgroundCompensationMenuView = {
 // Tube HV profile menu
 
 static const char *const tubeHVProfileMenuOptions[] = {
-    "Factory default",
+    "Factory Default",
 #if defined(TUBE_HVPROFILE_ACCURACY_FREQUENCY)
     "Accuracy",
 #endif
 #if defined(TUBE_HVPROFILE_ENERGYSAVING_FREQUENCY)
-    "Energy-saving",
+    "Energy-Saving",
 #endif
-    "Custom profile",
+    "Custom Profile",
     NULL,
 };
 
@@ -424,7 +428,7 @@ static void onTubeHVProfileMenuSelect(const Menu *menu)
 static MenuState tubeHVProfileMenuState;
 
 static const Menu tubeHVProfileMenu = {
-    "HV profile",
+    "HV Profile",
     &tubeHVProfileMenuState,
     onTubeHVProfileMenuGetOption,
     onTubeHVProfileMenuSelect,
@@ -480,8 +484,8 @@ static const View tubeHVCustomProfileWarningView = {
 // Tube HV custom profile menu
 
 static const char *const tubeHVCustomProfileMenuOptions[] = {
-    "PWM frequency",
-    "PWM duty cycle",
+    "PWM Frequency",
+    "PWM Duty Cycle",
     NULL,
 };
 
@@ -512,7 +516,7 @@ static void onTubeHVCustomProfileMenuSelect(const Menu *menu)
 static MenuState tubeHVCustomProfileMenuState;
 
 static const Menu tubeHVCustomProfileMenu = {
-    "Custom profile",
+    "Custom Profile",
     &tubeHVCustomProfileMenuState,
     onTubeHVCustomProfileMenuGetOption,
     onTubeHVCustomProfileMenuSelect,
@@ -592,7 +596,7 @@ static void onTubeHVFrequencyMenuSelect(const Menu *menu)
 static MenuState tubeHVFrequencyMenuState;
 
 static const Menu tubeHVFrequencyMenu = {
-    "PWM frequency",
+    "PWM Frequency",
     &tubeHVFrequencyMenuState,
     onTubeHVFrequencyMenuGetOption,
     onTubeHVFrequencyMenuSelect,
@@ -666,7 +670,7 @@ static void onTubeHVDutyCycleMenuSelect(const Menu *menu)
 static MenuState tubeHVDutyCycleMenuState;
 
 static const Menu tubeHVDutyCycleMenu = {
-    "PWM duty cycle",
+    "PWM Duty Cycle",
     &tubeHVDutyCycleMenuState,
     onTubeHVDutyCycleMenuGetOption,
     onTubeHVDutyCycleMenuSelect,
@@ -694,15 +698,15 @@ enum
 };
 
 static const char *const pulsesMenuOptions[] = {
-    "Pulse clicks",
+    "Pulse Clicks",
 #if defined(PULSE_LED)
     "Pulse LED",
 #endif
-    "Display flashes",
+    "Display Flashes",
 #if defined(VIBRATOR)
-    "Haptic pulses",
+    "Haptic Pulses",
 #endif
-    "Pulses threshold",
+    "Pulses Threshold",
     NULL,
 };
 

--- a/platform.io/src/vibrator.c
+++ b/platform.io/src/vibrator.c
@@ -51,7 +51,7 @@ static void onPulseVibrationsMenuSelect(const Menu *menu)
 static MenuState pulseVibrationsMenuState;
 
 static const Menu pulseVibrationsMenu = {
-    "Haptic pulses",
+    "Haptic Pulses",
     &pulseVibrationsMenuState,
     onPulseVibrationsMenuGetOption,
     onPulseVibrationsMenuSelect,


### PR DESCRIPTION
Consistent case for menu items.
Alternate consolidation of certain longer strings.
Fix "Life pulses" displayed again instead of "Dead Time" in statistics.
Added time display format setting. (24-hour and 12-hour)

These are slightly pedantic and subjective changes, so I wont be offended if you don't take them.
