### PR TITLE
Contain exceptions when the data log format is invalid

### DIFF
--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -190,11 +190,17 @@ def download_datalog(device, path, start_datetime):
             values = record.split(',')
 
             if (len(values) != 2):
-                print('Warning: invalid data log format in line ' + str(index) + ' is skipped: ' + record);
+                print('Warning: invalid data log format in line ' +
+                      str(index) + ' is skipped: ' + record);
                 continue
 
-            record_time = int(values[0])
-            pulse_count = int(values[1])
+            try:
+                record_time = int(values[0])
+                pulse_count = int(values[1])
+            except:
+                print('Warning: invalid data log format in line ' +
+                      str(index) + ' is skipped: ' + record)
+                continue
 
             try:
                 record_datetime = str(datetime.fromtimestamp(record_time))

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -189,10 +189,19 @@ def download_datalog(device, path, start_datetime):
 
             values = record.split(',')
 
+            if (len(values) != 2):
+                print('Warning: invalid data log format in line ' + str(index) + ' is skipped: ' + record);
+                continue
+
             record_time = int(values[0])
             pulse_count = int(values[1])
 
-            record_datetime = str(datetime.fromtimestamp(record_time))
+            try:
+                record_datetime = str(datetime.fromtimestamp(record_time))
+            except:
+                print('Warning: invalid date time format in line ' +
+                      str(index) + ' is skipped: ' + record)
+                continue
 
             if last_pulse_count != None:
                 delta_time = record_time - last_time


### PR DESCRIPTION
Fixes #245 

To fix the issue mentioned in the issue report, I've added a check on the result of the splitting of datalog entries, and also a try closure around the datetime conversion. Ignoring the entry in both cases, and logging out the skipped data.

Unfortunately I've reset my datalog on the device before realizinh that the raw output of the serial api would be useful to understand why the malformed entries are present at the first place, will try to reproduce it later.

After these changes, the download was successful:
```
 :: ~ » radpro-tool --port /dev/cu.usbserial-313120 --download-datalog ~/Unclutter/radpro.csv
Syncing time...
Downloading data log...
Warning: invalid data log format in line 11029 is skipped:
Warning: invalid data log format in line 11372 is skipped: 1745944186914
Warning: invalid data log format in line 15649 is skipped: 1745986967,1077,109703
Warning: invalid data log format in line 16314 is skipped: 1745992
Warning: invalid data log format in line 17276 is skipped: 1746003241,1746003251,116771
Warning: invalid data log format in line 17597 is skipped: 1746006461,11781,117814
Logging live...
```