### PR TITLE
Update FNIRSI GC-01 instructions with tip to copy the file twice

### DIFF
--- a/docs/devices/FNIRSI GC-01/install.md
+++ b/docs/devices/FNIRSI GC-01/install.md
@@ -34,6 +34,7 @@ This guide explains how to install the Rad Pro firmware on FNIRSI GC-01 and JOY-
 
 * Some devices require holding the **Power** button from power-on until the firmware is copied and the device restarts.
 * Others may need the **Right/Settings** and **OK/Power** keys pressed together to make the USB drive available.
+* You may have to copy the file to the USB drive twice.
 
 **Troubleshooting:**
 
@@ -124,3 +125,4 @@ If you find Rad Pro useful:
 * **HV profile settings:**
   * Factory default: 47.058 kHz frequency, 50% duty cycle.
   * Energy-saving: 5 kHz frequency, 1.5% duty cycle.
+


### PR DESCRIPTION
I personally had to copy the file twice. I literally did the following:

```
cp fnirsi-gc01_apm32f103rb/install/radpro-fnirsi-gc01_apm32f103rb-en-3.0.1-install.bin /media/BOOTLOADER
cp fnirsi-gc01_apm32f103rb/install/radpro-fnirsi-gc01_apm32f103rb-en-3.0.1-install.bin /media/BOOTLOADER
```

and that's the only way I got it to work properly.

This is also reported before:

* https://github.com/Gissio/radpro/discussions/113
* https://github.com/Gissio/radpro/discussions/247