### PR TITLE
Develop

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -215,6 +215,24 @@ The [random generator](https://en.wikipedia.org/wiki/Hardware_random_number_gene
   python tools/radpro-tool.py --port COM13 --submit-gmcmap [USER_ACCOUNT_ID] [GEIGER_COUNTER_ID]
   ```
 
+- Submit data to [radmon.org](https://radmon.org):
+
+  ```bash
+  python tools/radpro-tool.py --port COM13 --submit-radmon [USERNAME] [DATA_SENDING_PASSWORD]
+  ```
+
+- Submit data to [safecast.org](https://safecast.org):
+
+  ```bash
+  python tools/radpro-tool.py --port COM13 --submit-safecast [API_KEY] [DEVICE_ID]
+  ```
+
+- Submit data to [safecast.org](https://safecast.org) with location data:
+
+  ```bash
+  python tools/radpro-tool.py --port COM13 --submit-safecast [API_KEY] [DEVICE_ID] --safecast-latitude 37.7749 --safecast-longitude -122.4194 --safecast-height 100.5
+  ```
+
 ## Data communications
 
 Refer to the [communications protocol description](comm.md) for USB serial port communication details.

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -392,13 +392,14 @@ def stream_datalog(io, args):
             prev_timestamp = curr_timestamp
             prev_pulsecount = curr_pulsecount
 
-            curr_datetime = str(datetime.fromtimestamp(curr_timestamp))
+            curr_datetime = datetime.fromtimestamp(curr_timestamp)
 
             if args.pulsedata_file != None and curr_pulsecount != None:
+                curr_datetime_str = str(curr_datetime)
                 if cpm != None:
-                    line = f'{curr_timestamp},{curr_datetime},{curr_pulsecount},{cpm:.1f},{uSvH:.3f}\n'
+                    line = f'{curr_timestamp},{curr_datetime_str},{curr_pulsecount},{cpm:.1f},{uSvH:.3f}\n'
                 else:
-                    line = f'{curr_timestamp},{curr_datetime},{curr_pulsecount},,\n'
+                    line = f'{curr_timestamp},{curr_datetime_str},{curr_pulsecount},,\n'
 
                 try:
                     open(args.pulsedata_file, 'at').write(line)
@@ -412,7 +413,7 @@ def stream_datalog(io, args):
                     f'&CPM={cpm:.0f}' + f'&ACPM={cpm:.3f}' + \
                     f'&uSV={uSvH:.3f}'
                 send_http_request(url, 'get', headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
-                print(f'GMCMap submission - DateTime: {datetime.fromtimestamp(curr_timestamp)}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
+                print(f'GMCMap submission - DateTime: {curr_datetime}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
 
             if args.submit_radmon != None and cpm != None:
                 url = 'https://radmon.org/radmon.php?function=submit' + \
@@ -420,7 +421,7 @@ def stream_datalog(io, args):
                     f'&password={args.submit_radmon[1]}' + \
                     f'&value={cpm:.3f}' + '&unit=CPM'
                 send_http_request(url, headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
-                print(f'Radmon submission - DateTime: {datetime.fromtimestamp(curr_timestamp)}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
+                print(f'Radmon submission - DateTime: {curr_datetime}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
 
             if args.submit_safecast != None and cpm != None:
                 url = 'https://api.safecast.org/measurements.json?api_key=' + \
@@ -435,7 +436,7 @@ def stream_datalog(io, args):
                     'height': str(args.safecast_height),
                 }
                 send_http_request(url, 'post', json, headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
-                print(f'Safecast submission - DateTime: {datetime.fromtimestamp(curr_timestamp)}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
+                print(f'Safecast submission - DateTime: {curr_datetime}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
 
         # Wait for next measurement
         next_event += args.period

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -329,17 +329,17 @@ def download_datalog(io,
         log_warning(f'could not write {path}')
 
 
-def send_http_request(url, method='get', json=None, data=None):
+def send_http_request(url, method='get', json=None, data=None, headers=None):
     try:
         if method == 'get':
-            requests.get(url=url, timeout=60)
+            requests.get(url=url, timeout=60, headers=headers)
         elif method == 'post':
             if json is not None:
-                requests.post(url=url, json=json, timeout=60)
+                requests.post(url=url, json=json, timeout=60, headers=headers)
             elif data is not None:
-                requests.post(url=url, data=data, timeout=60)
+                requests.post(url=url, data=data, timeout=60, headers=headers)
             else:
-                requests.post(url=url, timeout=60)
+                requests.post(url=url, timeout=60, headers=headers)
     except Exception as e:
         log_warning(f'could not submit HTTP data: url "{url}": {e}')
 
@@ -410,14 +410,14 @@ def stream_datalog(io, args):
                     f'?AID={args.submit_gmcmap[0]}' + f'&GID={args.submit_gmcmap[1]}' + \
                     f'&CPM={cpm:.0f}' + f'&ACPM={cpm:.3f}' + \
                     f'&uSV={uSvH:.3f}'
-                send_http_request(url, 'post')
+                send_http_request(url, 'get', headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
 
             if args.submit_radmon != None and cpm != None:
                 url = 'https://radmon.org/radmon.php?function=submit' + \
                     f'&user={args.submit_radmon[0]}' + \
                     f'&password={args.submit_radmon[1]}' + \
                     f'&value={cpm:.3f}' + '&unit=CPM'
-                send_http_request(url)
+                send_http_request(url, headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
 
             if args.submit_safecast != None and cpm != None:
                 url = 'https://api.safecast.org/measurements.json?api_key=' + \
@@ -431,7 +431,7 @@ def stream_datalog(io, args):
                     'longitude': str(args.safecast_longitude),
                     'height': str(args.safecast_height),
                 }
-                send_http_request(url, 'post', json)
+                send_http_request(url, 'post', json, headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
 
         # Wait for next measurement
         next_event += args.period

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -329,12 +329,17 @@ def download_datalog(io,
         log_warning(f'could not write {path}')
 
 
-def send_http_request(url, method='get', json=None):
+def send_http_request(url, method='get', json=None, data=None):
     try:
         if method == 'get':
             requests.get(url=url, timeout=60)
         elif method == 'post':
-            requests.post(url=url, json=json, timeout=60)
+            if json is not None:
+                requests.post(url=url, json=json, timeout=60)
+            elif data is not None:
+                requests.post(url=url, data=data, timeout=60)
+            else:
+                requests.post(url=url, timeout=60)
     except Exception as e:
         log_warning(f'could not submit HTTP data: url "{url}": {e}')
 
@@ -405,7 +410,7 @@ def stream_datalog(io, args):
                     f'?AID={args.submit_gmcmap[0]}' + f'&GID={args.submit_gmcmap[1]}' + \
                     f'&CPM={cpm:.0f}' + f'&ACPM={cpm:.3f}' + \
                     f'&uSV={uSvH:.3f}'
-                send_http_request(url)
+                send_http_request(url, 'post')
 
             if args.submit_radmon != None and cpm != None:
                 url = 'https://radmon.org/radmon.php?function=submit' + \

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -422,9 +422,9 @@ def stream_datalog(io, args):
                     'unit': 'cpm',
                     'device_id': args.submit_safecast[1],
                     'captured_at': f'"{curr_datetime.isoformat()}"',
-                    'latitude': '0',
-                    'longitude': '0',
-                    'height': '0',
+                    'latitude': str(args.safecast_latitude),
+                    'longitude': str(args.safecast_longitude),
+                    'height': str(args.safecast_height),
                 }
                 send_http_request(url, 'post', json)
 
@@ -498,6 +498,18 @@ def main():
                         metavar=('API_KEY', 'DEVICE_ID'),
                         action='store',
                         help='submit live data to https://safecast.org')
+    parser.add_argument('--safecast-latitude',
+                        type=float,
+                        default=0.0,
+                        help='latitude for Safecast submissions (default: 0.0)')
+    parser.add_argument('--safecast-longitude',
+                        type=float,
+                        default=0.0,
+                        help='longitude for Safecast submissions (default: 0.0)')
+    parser.add_argument('--safecast-height',
+                        type=float,
+                        default=0.0,
+                        help='height/altitude for Safecast submissions (default: 0.0)')
     parser.add_argument('--log-randomdata',
                         dest='randomdata_file',
                         help='log live randomly generated data to a binary file')

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -392,8 +392,9 @@ def stream_datalog(io, args):
             prev_timestamp = curr_timestamp
             prev_pulsecount = curr_pulsecount
 
+            curr_datetime = str(datetime.fromtimestamp(curr_timestamp))
+
             if args.pulsedata_file != None and curr_pulsecount != None:
-                curr_datetime = str(datetime.fromtimestamp(curr_timestamp))
                 if cpm != None:
                     line = f'{curr_timestamp},{curr_datetime},{curr_pulsecount},{cpm:.1f},{uSvH:.3f}\n'
                 else:

--- a/tools/radpro-tool.py
+++ b/tools/radpro-tool.py
@@ -411,6 +411,7 @@ def stream_datalog(io, args):
                     f'&CPM={cpm:.0f}' + f'&ACPM={cpm:.3f}' + \
                     f'&uSV={uSvH:.3f}'
                 send_http_request(url, 'get', headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
+                print(f'GMCMap submission - DateTime: {datetime.fromtimestamp(curr_timestamp)}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
 
             if args.submit_radmon != None and cpm != None:
                 url = 'https://radmon.org/radmon.php?function=submit' + \
@@ -418,6 +419,7 @@ def stream_datalog(io, args):
                     f'&password={args.submit_radmon[1]}' + \
                     f'&value={cpm:.3f}' + '&unit=CPM'
                 send_http_request(url, headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
+                print(f'Radmon submission - DateTime: {datetime.fromtimestamp(curr_timestamp)}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
 
             if args.submit_safecast != None and cpm != None:
                 url = 'https://api.safecast.org/measurements.json?api_key=' + \
@@ -432,6 +434,7 @@ def stream_datalog(io, args):
                     'height': str(args.safecast_height),
                 }
                 send_http_request(url, 'post', json, headers={'User-Agent': 'radpro-tool/' + radpro_tool_version})
+                print(f'Safecast submission - DateTime: {datetime.fromtimestamp(curr_timestamp)}, CPM: {cpm:.3f}, uSv/h: {uSvH:.3f}')
 
         # Wait for next measurement
         next_event += args.period


### PR DESCRIPTION
A pull request with fixes and changes within radpro-tool.py.
- Safemon integration was basically not working because of "curr_datetime" is not visible on it. Fixed
- Added documentation
- Added Location parameters to Safemon (because it does not provide a way to hardcoding meter location like in gmcmap)
- Put additional header: 'User-Agent': 'radpro-tool/' + radpro_tool_version} when sending request because gmcmap added some new firewall/ACL rules to not allow request with this header set to generic python script. I Described the issue in: https://github.com/Gissio/radpro/issues/310. It should fix that.

Summary
**New data submission features:**

* Added documentation about submitting data to [radmon.org](https://radmon.org) and [safecast.org](https://safecast.org) via new command-line options in `radpro-tool.py`, including the ability to provide API keys, device IDs, and user credentials. [[1]](diffhunk://#diff-8b611c63a98d96b60454bca54304d95f3873e553cd56bed2663fa6b0a6eb8f2fR218-R235) [[2]](diffhunk://#diff-14b8fb30bb7f1a67c17b64275b1ccba34a1f001a1b5af15878b67ee71916a2d5R511-R522)
* Added options to specify latitude, longitude, and height for Safecast submissions, allowing users to include location data with their measurements. [[1]](diffhunk://#diff-14b8fb30bb7f1a67c17b64275b1ccba34a1f001a1b5af15878b67ee71916a2d5R511-R522) [[2]](diffhunk://#diff-14b8fb30bb7f1a67c17b64275b1ccba34a1f001a1b5af15878b67ee71916a2d5L425-R439)

**Improvements to HTTP requests and logging:**

* Enhanced the `send_http_request` function to support custom headers and sending both JSON and form data, making it more flexible for different submission endpoints.
* Updated all data submission requests to include a custom `User-Agent` header and improved logging by printing a summary after each submission.
* Refined the format of the timestamp in pulse data files for consistency and clarity.