### PR TITLE
Added temperature readout for L4 and G0 devices

### DIFF
--- a/platform.io/lib/stm32/stm32-ext.h
+++ b/platform.io/lib/stm32/stm32-ext.h
@@ -2114,13 +2114,20 @@ __STATIC_INLINE void dma_disable(DMA_Channel_TypeDef *channel)
 #define VREFINT_VOLTAGE 1.2F
 #elif defined(STM32G0)
 #define TS_CAL1 (*((__I uint16_t *)0x1fff75a8))
+#define TS_CAL2 (*((__I uint16_t *)0x1fff75ca))
+#define TS_CAL1_TEMP 30.0F
+#define TS_CAL2_TEMP 130.0F
 #define VREFINT_CAL_VALUE (*((__I uint16_t *)0x1fff75aa))
 #define VREFINT_CAL_VOLTAGE 3.0F
+#define ADC_TS_CHANNEL 12u
 #elif defined(STM32L4)
 #define TS_CAL1 (*((__I uint16_t *)0x1fff75a8))
 #define TS_CAL2 (*((__I uint16_t *)0x1fff75ca))
+#define TS_CAL1_TEMP 30.0F
+#define TS_CAL2_TEMP 130.0F
 #define VREFINT_CAL_VALUE (*((__I uint16_t *)0x1fff75aa))
 #define VREFINT_CAL_VOLTAGE 3.0F
+#define ADC_TS_CHANNEL 17u
 #endif
 
 #define UID0 (((__I uint32_t *)UID_BASE)[0])

--- a/platform.io/src/adc.h
+++ b/platform.io/src/adc.h
@@ -15,5 +15,6 @@
 void initADC(void);
 
 float readBatteryVoltage(void);
+float readTemperature(void);
 
 #endif

--- a/platform.io/src/display.c
+++ b/platform.io/src/display.c
@@ -23,6 +23,7 @@
 #include "system.h"
 #include "tube.h"
 #include "view.h"
+#include "adc.h"
 
 // Defines
 
@@ -2169,8 +2170,12 @@ void drawStatistics(void)
         case STATISTICS_VOLTAGE:
             strcatFloat(valueString, getBatteryVoltage(), 3);
             strclr(unitString);
-            strcatChar(unitString, ' ');
             strcat(unitString, getString(STRING_VOLTS));
+#if (defined(STM32G0) || defined(STM32L4))
+            strcatChar(unitString, ' ');
+            strcatFloat(unitString, readTemperature(), 1);
+            strcat(unitString, getString(STRING_TEMPERATURE));
+#endif
 
             break;
         }

--- a/platform.io/src/stm32/stm32_adc.c
+++ b/platform.io/src/stm32/stm32_adc.c
@@ -67,4 +67,26 @@ float readBatteryVoltage(void)
     return value;
 }
 
+
+float readTemperature(void)
+{
+    adc_enable(ADC1);
+
+#if (defined(STM32G0) || defined(STM32L4))
+    adc_enable_temperature_channel(ADC1);
+    uint32_t tempValue = readADC(ADC_TS_CHANNEL);
+    adc_disable_temperature_channel(ADC1);
+
+    float value = (TS_CAL2_TEMP - TS_CAL1_TEMP) / (TS_CAL2 - TS_CAL1)
+                 * ((float)tempValue - TS_CAL1) + TS_CAL1_TEMP;
+    
+#else
+    float value = 0.0F;
+#endif
+
+    adc_disable(ADC1);
+
+    return value;
+}
+
 #endif

--- a/platform.io/src/strings/bg.h
+++ b/platform.io/src/strings/bg.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "имп."

--- a/platform.io/src/strings/cs.h
+++ b/platform.io/src/strings/cs.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/da.h
+++ b/platform.io/src/strings/da.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "tæl."

--- a/platform.io/src/strings/de.h
+++ b/platform.io/src/strings/de.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "Imp."

--- a/platform.io/src/strings/el.h
+++ b/platform.io/src/strings/el.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "παλμός"

--- a/platform.io/src/strings/en.h
+++ b/platform.io/src/strings/en.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "count"

--- a/platform.io/src/strings/es.h
+++ b/platform.io/src/strings/es.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "pulso"

--- a/platform.io/src/strings/fi.h
+++ b/platform.io/src/strings/fi.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "pulssi"

--- a/platform.io/src/strings/fr.h
+++ b/platform.io/src/strings/fr.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/hr.h
+++ b/platform.io/src/strings/hr.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/hu.h
+++ b/platform.io/src/strings/hu.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "db"

--- a/platform.io/src/strings/id.h
+++ b/platform.io/src/strings/id.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "cacah"

--- a/platform.io/src/strings/it.h
+++ b/platform.io/src/strings/it.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/ja.h
+++ b/platform.io/src/strings/ja.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "回"

--- a/platform.io/src/strings/ko.h
+++ b/platform.io/src/strings/ko.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "회"

--- a/platform.io/src/strings/lt.h
+++ b/platform.io/src/strings/lt.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/nl.h
+++ b/platform.io/src/strings/nl.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "tell."

--- a/platform.io/src/strings/no.h
+++ b/platform.io/src/strings/no.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "tell"

--- a/platform.io/src/strings/pl.h
+++ b/platform.io/src/strings/pl.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/pt.h
+++ b/platform.io/src/strings/pt.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "pulso"

--- a/platform.io/src/strings/ro.h
+++ b/platform.io/src/strings/ro.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/ru.h
+++ b/platform.io/src/strings/ru.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "имп."

--- a/platform.io/src/strings/sk.h
+++ b/platform.io/src/strings/sk.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/sl.h
+++ b/platform.io/src/strings/sl.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "imp."

--- a/platform.io/src/strings/sv.h
+++ b/platform.io/src/strings/sv.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "puls"

--- a/platform.io/src/strings/tr.h
+++ b/platform.io/src/strings/tr.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "sayım"

--- a/platform.io/src/strings/uk.h
+++ b/platform.io/src/strings/uk.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "имп."

--- a/platform.io/src/strings/vi.h
+++ b/platform.io/src/strings/vi.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "lần"

--- a/platform.io/src/strings/zh_CN.h
+++ b/platform.io/src/strings/zh_CN.h
@@ -37,6 +37,7 @@
 #define STRING_VOLTS "V"
 #define STRING_KHZ "kHz"
 #define STRING_CPMUSVH "cpm/µSv/h"
+#define STRING_TEMPERATURE "C"
 
 // Units for indicating Geiger tube pulse count, as in "1 count" or "14 counts"
 #define STRING_COUNT "次"


### PR DESCRIPTION
I added readout of internal temperature sensor for my FS-5000 with L4 derivative. It should work as well on G0 but this is untested due to lack of device.

The temperature is placed in Statistics behind battery voltage. That may or may not be a good idea.

Please consider.
