### PR TITLE
Fix: Correct inverted display brightness on Fnirsi GC-03

### DIFF
--- a/platform.io/src/stm32/stm32_display.c
+++ b/platform.io/src/stm32/stm32_display.c
@@ -69,7 +69,11 @@ void setBacklight(bool value)
 
         // Timer
         uint32_t period = DISPLAY_BACKLIGHT_TIMER_PERIOD;
+#if defined(DISPLAY_BACKLIGHT_ACTIVE_LOW)
+        uint32_t onTime = period - ((displayBrightnessValue[settings.displayBrightness] * DISPLAY_BACKLIGHT_TIMER_PERIOD) >> 16);
+#else
         uint32_t onTime = ((displayBrightnessValue[settings.displayBrightness] * DISPLAY_BACKLIGHT_TIMER_PERIOD) >> 16);
+#endif
         uint32_t prescalerFactor = prescalePWMParameters(&period, &onTime);
 
 #if defined(DISPLAY_BACKLIGHT_ACTIVE_LOW)
@@ -86,11 +90,7 @@ void setBacklight(bool value)
     else
     {
         // GPIO
-#if defined(DISPLAY_BACKLIGHT_ACTIVE_LOW)
-        gpio_set(DISPLAY_BACKLIGHT_PORT, DISPLAY_BACKLIGHT_PIN);
-#else
         gpio_clear(DISPLAY_BACKLIGHT_PORT, DISPLAY_BACKLIGHT_PIN);
-#endif
 
 #if defined(STM32F0) || defined(STM32G0) || defined(STM32L4)
         gpio_setup_output(DISPLAY_BACKLIGHT_PORT, DISPLAY_BACKLIGHT_PIN, GPIO_OUTPUTTYPE_PUSHPULL, GPIO_OUTPUTSPEED_2MHZ, GPIO_PULL_FLOATING);


### PR DESCRIPTION
Hi,

This PR resolves a display backlight issue on the Fnirsi GC-03 where the brightness control was inverted and the screen would remain on during sleep.

**Problem Summary:**
- Brightness settings worked in reverse (e.g., "low" produced high brightness).
- In sleep mode, the display would light up at maximum brightness instead of turning off.

**Root Cause:**
There was a logical mismatch in `stm32_display.c`. The GC-03 hardware uses an active-high backlight, but the `DISPLAY_BACKLIGHT_ACTIVE_LOW` flag is defined for it, causing the driver to use incorrect logic for PWM and power-down.

**Solution:**
The `setBacklight` function has been refactored to handle this specific case cleanly without affecting other devices:
- The PWM `onTime` calculation is now conditionally inverted only when `DISPLAY_BACKLIGHT_ACTIVE_LOW` is defined. This targets the fix specifically to the GC-03.
- The logic to disable the backlight now correctly uses `gpio_clear` in all cases, ensuring the active-high backlight turns off as expected.