### PR TITLE
Add volume control for buzzer sound pulses

### DIFF
--- a/platform.io/src/peripherals/buzzer.c
+++ b/platform.io/src/peripherals/buzzer.c
@@ -17,6 +17,7 @@
 void setupBuzzer(void)
 {
     selectMenuItem(&soundPulsesMenu, settings.soundPulseType);
+    selectMenuItem(&soundPulsesVolumeMenu, settings.soundPulseVolume);
 }
 
 // Sound pulses menu
@@ -47,6 +48,37 @@ const Menu soundPulsesMenu = {
     ARRAY_SIZE(soundPulsesMenuOptions),
     onSoundPulsesMenuGetOption,
     onSoundPulsesMenuSelect,
+    showSoundMenu,
+};
+
+// Sound pulse volume menu
+
+static cstring soundPulseVolumeOptions[] = {
+    STRING_LOW,
+    STRING_MEDIUM,
+    STRING_HIGH,
+};
+
+static const char *onSoundPulsesVolumeMenuGetOption(menu_size_t index, MenuStyle *menuStyle)
+{
+    *menuStyle = (index == settings.soundPulseVolume);
+
+    return getString(soundPulseVolumeOptions[index]);
+}
+
+static void onSoundPulsesVolumeMenuSelect(menu_size_t index)
+{
+    settings.soundPulseVolume = index;
+}
+
+static MenuState soundPulsesVolumeMenuState;
+
+const Menu soundPulsesVolumeMenu = {
+    STRING_PULSEVOLUME,
+    &soundPulsesVolumeMenuState,
+    ARRAY_SIZE(soundPulseVolumeOptions),
+    onSoundPulsesVolumeMenuGetOption,
+    onSoundPulsesVolumeMenuSelect,
     showSoundMenu,
 };
 

--- a/platform.io/src/peripherals/buzzer.h
+++ b/platform.io/src/peripherals/buzzer.h
@@ -15,6 +15,7 @@
 #include "../ui/menu.h"
 
 extern const Menu soundPulsesMenu;
+extern const Menu soundPulsesVolumeMenu;
 
 void initBuzzer(void);
 

--- a/platform.io/src/peripherals/sound.c
+++ b/platform.io/src/peripherals/sound.c
@@ -88,6 +88,7 @@ static const Menu soundAlertStyleMenu = {
 static const MenuOption soundMenuOptions[] = {
 #if defined(BUZZER)
     {STRING_PULSES, &soundPulsesMenu},
+    {STRING_PULSEVOLUME, &soundPulsesVolumeMenu},
 #endif
     {STRING_ALERTSTYLE, &soundAlertStyleMenu},
 #if defined(VOICE)

--- a/platform.io/src/stm32/stm32_buzzer.c
+++ b/platform.io/src/stm32/stm32_buzzer.c
@@ -13,6 +13,7 @@
 
 #include "../peripherals/buzzer.h"
 #include "../system/events.h"
+#include "../system/settings.h"
 #include "../stm32/device.h"
 
 void initBuzzer(void)
@@ -76,7 +77,17 @@ void setBuzzer(bool value)
 
 #else
 
-    tim_set_ontime(BUZZER_TIMER, BUZZER_TIMER_CHANNEL, value ? BUZZER_TIMER_PERIOD / 2 : 0);
+    static const uint32_t buzzerVolumeLevels[] = {
+        BUZZER_TIMER_PERIOD / 64,
+        BUZZER_TIMER_PERIOD / 16,
+        BUZZER_TIMER_PERIOD / 2,
+    };
+
+    uint32_t onTime = 0;
+    if (value)
+        onTime = buzzerVolumeLevels[settings.soundPulseVolume];
+
+    tim_set_ontime(BUZZER_TIMER, BUZZER_TIMER_CHANNEL, onTime);
 
 #endif
 }

--- a/platform.io/src/system/settings.c
+++ b/platform.io/src/system/settings.c
@@ -65,6 +65,7 @@ static const Settings defaultSettings = {
     .soundAlertStyle = SOUND_ALERTSTYLE_LONG,
 #endif
     .soundAlertVolume = SOUND_ALERTVOLUME_VERYHIGH,
+    .soundPulseVolume = SOUND_PULSEVOLUME_HIGH,
     .soundVoiceVolume = SOUND_VOICEVOLUME_VERYHIGH,
 
     .rtcTimeZone = RTC_TIMEZONE_P0000,
@@ -140,6 +141,7 @@ static bool validateState(const State *state)
 #endif
             (s->displaySleep < DISPLAY_SLEEP_NUM) &&
             (s->soundPulseType < SOUND_PULSETYPE_NUM) &&
+            (s->soundPulseVolume < SOUND_PULSEVOLUME_NUM) &&
             (s->rtcTimeZone < RTC_TIMEZONE_NUM) &&
 #if defined(BATTERY_REMOVABLE)
             (s->powerBatteryType < BATTERYTYPE_NUM) &&

--- a/platform.io/src/system/settings.h
+++ b/platform.io/src/system/settings.h
@@ -326,6 +326,16 @@ enum
 
 enum
 {
+    SOUND_PULSEVOLUME_LOW,
+    SOUND_PULSEVOLUME_MEDIUM,
+    SOUND_PULSEVOLUME_HIGH,
+
+    SOUND_PULSEVOLUME_NUM,
+};
+
+
+enum
+{
     SOUND_ALERTVOLUME_LOW,
     SOUND_ALERTVOLUME_MEDIUM,
     SOUND_ALERTVOLUME_HIGH,
@@ -459,6 +469,7 @@ typedef struct
     unsigned int displaySleep : 3;
 
     unsigned int soundPulseType : 2;
+    unsigned int soundPulseVolume : 2;
     unsigned int soundAlertStyle : 1;
     unsigned int soundAlertVolume : 2;
     unsigned int soundVoiceVolume : 2;

--- a/platform.io/src/system/strings/en.h
+++ b/platform.io/src/system/strings/en.h
@@ -236,6 +236,7 @@
 #define STRING_ALERTSTYLE "Alert style"
 #define STRING_ALERTVOLUME "Alert volume"
 #define STRING_VOICEVOLUME "Voice volume"
+#define STRING_PULSEVOLUME "Pulse volume"
 
 // Sound alert style menu items
 #define STRING_SHORT "Short"

--- a/platform.io/src/system/strings/ru.h
+++ b/platform.io/src/system/strings/ru.h
@@ -236,6 +236,7 @@
 #define STRING_ALERTSTYLE "Стиль оповещения"
 #define STRING_ALERTVOLUME "Громкость оповещения"
 #define STRING_VOICEVOLUME "Громкость голоса"
+#define STRING_PULSEVOLUME "Громкость пульсации"
 
 // Sound alert style menu items
 #define STRING_SHORT "Короткий"


### PR DESCRIPTION
## Summary
This PR introduces a new setting to control the volume of the buzzer's sound pulses (particle clicks). The change was primarily developed and verified on the **Fnirsi GC-03**, where the default buzzer volume can be quite loud and sharp for indoor use.

## Changes
* **Menu Addition:** A new "Pulse volume" option has been added under the Sound settings, providing three levels: `Low`, `Medium`, and `High`.
* **Hardware/PWM Control:** The volume is controlled via PWM duty cycle adjustment in `stm32_buzzer.c`. Depending on the setting, the `onTime` is set to `1/64`, `1/16`, or `1/2` of the `BUZZER_TIMER_PERIOD`.
* **Verified on Fnirsi GC-03:** The duty cycle ratios (1/64, 1/16, 1/2) were tuned specifically to provide a meaningful difference in volume on the GC-03's hardware buzzer.
* **Settings Persistence:** Expanded the `Settings` struct (using 2 bits for `soundPulseVolume`) to save the preference. The default is set to `High` to ensure backward compatibility with the original sound level.
* **Localization:** Added strings for English and Russian (`Громкость пульсации`).

## Testing
Tested on a physical **Fnirsi GC-03** unit. All three volume levels work as expected, and the setting persists correctly after a reboot.