### PR TITLE
GC-03: map knob button to "OK"

### DIFF
--- a/platform.io/src/stm32/gc03.c
+++ b/platform.io/src/stm32/gc03.c
@@ -135,6 +135,7 @@ void initKeyboardHardware(void)
     gpio_setup(KEY_LEFT_PORT, KEY_LEFT_PIN, GPIO_MODE_INPUT_PULLUP);
     gpio_setup(KEY_RIGHT_PORT, KEY_RIGHT_PIN, GPIO_MODE_INPUT_PULLUP);
     gpio_setup(KNOB_A_PORT, KNOB_A_PIN, GPIO_MODE_INPUT_PULLUP);
+    gpio_setup(KNOB_BUTTON_PORT, KNOB_BUTTON_PIN, GPIO_MODE_INPUT_PULLUP);
     gpio_setup(KNOB_B_PORT, KNOB_B_PIN, GPIO_MODE_INPUT_PULLUP);
 
     KNOB_IRQ_HANDLER();
@@ -185,6 +186,7 @@ void onKeyboardTick(void)
 
     keyboardKeyDown[KEY_LEFT] |= !gpio_get(KEY_LEFT_PORT, KEY_LEFT_PIN);
     keyboardKeyDown[KEY_RIGHT] |= !gpio_get(KEY_RIGHT_PORT, KEY_RIGHT_PIN);
+    keyboardKeyDown[KEY_RIGHT] |= !gpio_get(KNOB_BUTTON_PORT, KNOB_BUTTON_PIN);
     keyboardKeyDown[KEY_OK] |= !gpio_get(KEY_POWER_PORT, KEY_POWER_PIN);
 }
 

--- a/platform.io/src/stm32/gc03.h
+++ b/platform.io/src/stm32/gc03.h
@@ -62,6 +62,8 @@
 #define KEY_POWER_PIN 9
 #define KNOB_A_PORT GPIOB
 #define KNOB_A_PIN 5
+#define KNOB_BUTTON_PORT GPIOB
+#define KNOB_BUTTON_PIN 6
 #define KNOB_B_PORT GPIOB
 #define KNOB_B_PIN 7
 #define KNOB_IRQ EXTI9_5_IRQn


### PR DESCRIPTION
The GC-03 is a six-button device (back, OK, knob left, knob right, knob button, power). There is currently no support for this, and the original firmware makes no use of the knob button either (it only emits a keyboard beep when pressed).

This PR maps the knob button to the same function as the "OK" button, making navigation more logical.